### PR TITLE
Arreglo de algunos errores  en el listado objetos

### DIFF
--- a/frontend/src/Layout.jsx
+++ b/frontend/src/Layout.jsx
@@ -11,6 +11,7 @@ import {
   Slider
 } from "@mui/material";
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 
 const Layout = () => {
   const [productos, setProductos] = useState([]);
@@ -160,6 +161,7 @@ const Layout = () => {
                   flexDirection: "column"
                 }}
               >
+                <Link to={`/show-item/${producto.id}`}>
                 <Card
                   sx={{
                     height: "100%",
@@ -190,6 +192,7 @@ const Layout = () => {
                     </Typography>
                   </CardContent>
                 </Card>
+                </Link>
               </Box>
             ))}
           </Box>

--- a/frontend/src/Layout.jsx
+++ b/frontend/src/Layout.jsx
@@ -34,6 +34,13 @@ const Layout = () => {
     setPrecio(newValue);
   }
 
+  const truncateDescription = (description, length = 100) => {
+    if (description.length > length) {
+      return description.substring(0, length) + "..."; 
+    }
+    return description;
+  };
+
   useEffect(() => {
     const fetchProducts = async () => {
       try {
@@ -182,13 +189,13 @@ const Layout = () => {
                       {producto.title}
                     </Typography>
                     <Typography variant="body2" gutterBottom>
-                      {producto.description}
-                    </Typography>
-                    <Typography variant="body2" gutterBottom>
                       {producto.category_display}
                     </Typography>
                     <Typography variant="body2">
                       {producto.price}€ / {producto.price_category_display}
+                    </Typography>
+                    <Typography variant="body2" gutterBottom>
+                      {truncateDescription(producto.description, 100)}
                     </Typography>
                   </CardContent>
                 </Card>

--- a/frontend/src/Layout.jsx
+++ b/frontend/src/Layout.jsx
@@ -8,7 +8,8 @@ import {
   TextField,
   Card,
   CardContent,
-  Slider
+  Slider,
+  Tooltip
 } from "@mui/material";
 import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
@@ -194,9 +195,14 @@ const Layout = () => {
                     <Typography variant="body2">
                       {producto.price}€ / {producto.price_category_display}
                     </Typography>
-                    <Typography variant="body2" gutterBottom>
-                      {truncateDescription(producto.description, 100)}
-                    </Typography>
+                    <Tooltip
+                      title={producto.description}
+                      arrow
+                    >
+                      <Typography variant="body2" gutterBottom>
+                        {truncateDescription(producto.description, 100)}
+                      </Typography>
+                    </Tooltip>
                   </CardContent>
                 </Card>
                 </Link>


### PR DESCRIPTION
Ya se puede clicar en un objeto en el listado de objetos y te lleva a sus detalles y se ha corregido la descripción que antes se mostraba entera ahora sólo 100 caracteres.