### PR TITLE
Frontend de perfil de empresa

### DIFF
--- a/frontend/src/SignUp.jsx
+++ b/frontend/src/SignUp.jsx
@@ -183,6 +183,11 @@ const Signup = () => {
       if (isCompany) {
         requiredFields.push("cif");
       }
+
+      if (!/^[A-HJ-NP-SUVW]\d{7}[0-9A-J]$/.test(formData.cif) && isCompany) {
+        errors.cif = "El NIF no es válido. Debe comenzar con una letra seguida de 7 dígitos y una letra o número final.";
+      }
+
     } catch (error) {
       console.error("Error verificando el nombre de usuario:", error);
       setError("Error verificando el nombre de usuario");

--- a/frontend/src/SignUp.jsx
+++ b/frontend/src/SignUp.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { FiUser, FiLock, FiMail, FiInfo } from "react-icons/fi";
+import { FiUser, FiLock, FiMail, FiInfo, FiBriefcase } from "react-icons/fi";
 import { AiOutlineEye, AiOutlineEyeInvisible } from "react-icons/ai";
 import { Checkbox, FormControlLabel } from "@mui/material"; 
 import axios from 'axios';
@@ -80,6 +80,7 @@ const Signup = () => {
     email: "",
     password: "",
     password2: "",
+    cif: "",
   });
   
   const [error, setError] = useState("");
@@ -90,17 +91,22 @@ const Signup = () => {
   const [showPassword2, setShowPassword2] = useState(false);
   const [acceptTerms, setAcceptTerms] = useState(false);
   const navigate = useNavigate();
+  const [isCompany, setIsCompany] = useState(false);
   
   useEffect(() => {
-    const { username, name, surname, email, password, password2 } = formData;
+    const { username, name, surname, email, password, password2, cif } = formData;
     const fields = [username, name, surname, email, password, password2];
   
+    if (isCompany) {
+      fields.push(cif);
+    }
+
     const isValid =
       fields.every(field => typeof field === 'string' && field.trim() !== "") &&
       acceptTerms;
   
     setIsFormValid(isValid);
-  }, [formData, acceptTerms]);
+  }, [formData, acceptTerms, isCompany]);
   
 
   const handleChange = (e) => {
@@ -117,6 +123,11 @@ const Signup = () => {
 
     if(!acceptTerms) {
       setError("Debe aceptar los términos y condiciones.");
+      return;
+    }
+    
+    if (isCompany && !formData.cif.trim()) {
+      setError("El campo NIF es obligatorio para perfiles de empresa.");
       return;
     }
 
@@ -168,6 +179,10 @@ const Signup = () => {
       if (usernameCheckResponse.data.exists) {
         errors.username = "El nombre de usuario ya existe.";
       }
+
+      if (isCompany) {
+        requiredFields.push("cif");
+      }
     } catch (error) {
       console.error("Error verificando el nombre de usuario:", error);
       setError("Error verificando el nombre de usuario");
@@ -207,6 +222,8 @@ const Signup = () => {
       });
   
       submitFormData.append("password1", formData.password); 
+
+      submitFormData.append("cif", formData.cif);
   
       console.log("Datos enviados:", Object.fromEntries(submitFormData.entries()));
   
@@ -407,6 +424,43 @@ const Signup = () => {
             />
             {formErrors.password2 && <FieldError>{formErrors.password2}</FieldError>}
 
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={isCompany}
+                  onChange={(e) => setIsCompany(e.target.checked)}
+                  color="primary"
+                />
+              }
+              label={
+                <Typography variant="body2">
+                  Perfil de empresa
+                </Typography>
+              }
+            />
+            {isCompany && (
+              <>
+                <StyledTextField
+                  variant="outlined"
+                  fullWidth
+                  label="NIF"
+                  name="cif"
+                  required
+                  value={formData.cif}
+                  onChange={handleChange}
+                  error={!!formErrors.cif}
+                  InputProps={{
+                    startAdornment: (
+                      <InputAdornment position="start">
+                        <FiBriefcase />
+                      </InputAdornment>
+                    ),
+                  }}
+                />
+                {formErrors.cif && <FieldError>{formErrors.cif}</FieldError>}
+              </>
+            )}
+            
             <FormControlLabel
                 control={
                   <Checkbox


### PR DESCRIPTION
Ya se pueden crear cuentas de empresa, en caso de seleccionar la casilla que indica que es un perfil de empresa se solicitará el NIF, el cual debe tener un formato concreto

`/^[A-HJ-NP-SUVW]\d{7}[0-9A-J]$/`

En caso de no seguir el formato, no se creará el usuario, de lo contrario si se creará, también en caso de no marcar la casilla de cuenta de empresa, el registro es el mismo de siempre.