### PR TITLE
Mejorar ventanas de confirmación

### DIFF
--- a/backend/objetos/models.py
+++ b/backend/objetos/models.py
@@ -246,6 +246,7 @@ class ItemRequest(models.Model):
         on_delete=models.CASCADE
         )
     created_at = models.DateTimeField(auto_now_add=True)
+    approved = models.BooleanField(default=False)
 
     def approve(self):
         """Método para aprobar la solicitud y crear un Item"""

--- a/frontend/src/CreateItem.jsx
+++ b/frontend/src/CreateItem.jsx
@@ -10,6 +10,7 @@ import { styled } from "@mui/system";
 //import DatePicker from 'react-datepicker';
 import { DateRange } from "react-date-range";
 import "react-datepicker/dist/react-datepicker.css";
+import PublishConfirmationDialog from "./components/PublishConfirmationDialog";
 
 const FormContainer = styled(Paper)(() => ({
   padding: "2rem",
@@ -233,6 +234,7 @@ const CreateItemScreen = () => {
   const [fetchingOptions, setFetchingOptions] = useState(true);
   const [isDraft, setIsDraft] = useState(false);
   const [filteredSubcategories, setFilteredSubcategories] = useState([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
     const fetchEnums = async () => {
@@ -576,6 +578,7 @@ const CreateItemScreen = () => {
   
       if (response.status === 201) {
         setSubmitSuccess(true);
+        setDialogOpen(true);  // Agrega aquí para mostrar el diálogo
         setTimeout(() => {
           if (isDraft) {
             navigate("/drafts");
@@ -882,6 +885,8 @@ const CreateItemScreen = () => {
         )}
         </FormContainer>
       </Container>
+      {/* Aquí va el diálogo de confirmación de publicación */}
+      <PublishConfirmationDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
   </Box>
   );
 };

--- a/frontend/src/CreateItemRequest.jsx
+++ b/frontend/src/CreateItemRequest.jsx
@@ -5,6 +5,7 @@ import Navbar from "./Navbar";
 import PropTypes from 'prop-types';
 import axios from 'axios';
 import CancelPolicyTooltip from "./components/CancelPolicyTooltip";
+import PublishConfirmationDialog from "./components/PublishConfirmationDialog";
 import { Box, Stack, Typography, Alert, CircularProgress, Paper, Container } from "@mui/material";
 import { styled } from "@mui/system";
 
@@ -153,6 +154,7 @@ const CreateItemRequestView = () => {
   const [showErrorMessage, setShowErrorMessage] = useState(false);
   const [fetchingOptions, setFetchingOptions] = useState(true);
   const [filteredSubcategories, setFilteredSubcategories] = useState([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
     const fetchEnums = async () => {
@@ -441,6 +443,7 @@ const CreateItemRequestView = () => {
   
       if (response.status === 201) {
         setSubmitSuccess(true);
+        setDialogOpen(true);  // Agrega aquí para mostrar el diálogo
         setTimeout(() => {
           navigate("/list_item_requests");
         }, 2000);
@@ -635,6 +638,8 @@ const CreateItemRequestView = () => {
           )}
         </FormContainer>
       </Container>
+      {/* Aquí va el diálogo de confirmación de publicación */}
+      <PublishConfirmationDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
     </Box>
   );
 };

--- a/frontend/src/ShowItem.jsx
+++ b/frontend/src/ShowItem.jsx
@@ -44,6 +44,9 @@ import Navbar from "./Navbar";
 import CancelPolicyTooltip from "./components/CancelPolicyTooltip";
 import SuccessModal from "./components/SuccessModal";
 import ConfirmModal from "./components/ConfirmModal";
+import DeleteConfirmationDialog from "./components/DeleteConfirmationDialog";
+import EditConfirmationDialog from "./components/EditConfirmationDialog";
+import PublishConfirmationDialog from "./components/PublishConfirmationDialog";
 import { Dialog, DialogTitle, DialogContent, DialogActions, TextField } from "@mui/material";
 
 
@@ -81,6 +84,7 @@ const ShowItemScreen = () => {
   const [showReportModal, setShowReportModal] = useState(false);
   const [reportCategory, setReportCategory] = useState("");
   const [reportDescription, setReportDescription] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   const currentUser = JSON.parse(localStorage.getItem("user"));
   console.log("currentUser", currentUser);
@@ -339,9 +343,6 @@ const ShowItemScreen = () => {
   };
 
   const handleDelete = async () => {
-    const confirmDelete = window.confirm("¿Estás seguro de que quieres eliminar este ítem?");
-    if (!confirmDelete) return;
-
     try {
       const token = localStorage.getItem("access_token")
       await axios.delete(
@@ -353,8 +354,6 @@ const ShowItemScreen = () => {
           },
         }
       );
-
-      alert("Ítem eliminado correctamente");
       navigate("/");
     } catch (error) {
       console.error("Error deleting item:", error);
@@ -468,7 +467,7 @@ const ShowItemScreen = () => {
       );
   
       if (response.status === 200) {
-        alert("¡El ítem se ha publicado correctamente!");
+        setDialogOpen(true);  // Agrega aquí para mostrar el diálogo
         navigate(0); // Refresca la página
       } else {
         alert("Hubo un problema al publicar el ítem.");
@@ -549,6 +548,7 @@ const ShowItemScreen = () => {
     >
       Publicar
     </Button>
+    <PublishConfirmationDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
   </Box>
 )}
 
@@ -768,21 +768,8 @@ const ShowItemScreen = () => {
                 
                 {isOwner && (
                   <Box sx={{ mt: 3, display: 'flex', gap: 2 }}>
-                    <Button 
-                      variant="outlined" 
-                      startIcon={<EditIcon />} 
-                      onClick={() => navigate(`/update-item/${id}`)}
-                    >
-                      Editar
-                    </Button>
-                    <Button 
-                      variant="outlined" 
-                      color="error" 
-                      startIcon={<DeleteIcon />} 
-                      onClick={handleDelete}
-                    >
-                      Eliminar
-                    </Button>
+                    <EditConfirmationDialog onConfirm={() => navigate(`/update-item/${id}`)} />
+                    <DeleteConfirmationDialog onConfirm={handleDelete} />
 
                     {/* Solo mostrar si el usuario NO es "free" */}
                     {currentUser.pricing_plan !== "free" && (

--- a/frontend/src/ShowItem.jsx
+++ b/frontend/src/ShowItem.jsx
@@ -26,9 +26,7 @@ import {
   InputLabel
 } from '@mui/material';
 
-import { 
-  Delete as DeleteIcon, 
-  Edit as EditIcon, 
+import {  
   Description as DescriptionIcon, 
   Category as CategoryIcon, 
   Cancel as CancelIcon, 

--- a/frontend/src/UpdateItem.jsx
+++ b/frontend/src/UpdateItem.jsx
@@ -30,6 +30,7 @@ import {
 import Navbar from "./Navbar";
 import axios from 'axios';
 import CancelPolicyTooltip from "./components/CancelPolicyTooltip";
+import SaveConfirmationDialog from "./components/SaveConfirmationDialog";
 import { DateRange } from "react-date-range";
 import { Delete } from "@mui/icons-material";
 
@@ -54,6 +55,7 @@ const UpdateItemScreen = () => {
   const [existingImages, setExistingImages] = useState([]);
   const [removedImages, setRemovedImages] = useState([]);
   const [filteredSubcategories, setFilteredSubcategories] = useState([]);
+  const [dialogOpen, setDialogOpen] = useState(false);
 
 
   useEffect(() => {
@@ -288,10 +290,12 @@ const UpdateItemScreen = () => {
           withCredentials: true,
         }
       );
+      setDialogOpen(true);
+      setTimeout(() => {
+        navigate("/");
+      }, 2000);
 
 
-      alert("¡Ítem actualizado exitosamente!");
-      navigate("/");
     } catch (error) {
       console.error("Error actualizando el ítem:", error);
       if (error.response) {
@@ -799,6 +803,7 @@ const UpdateItemScreen = () => {
           </Stack>
         </Box>
       </Paper>
+      <SaveConfirmationDialog open={dialogOpen} onClose={() => setDialogOpen(false)} />
     </Container>
   );
 };

--- a/frontend/src/components/DeleteConfirmationDialog.jsx
+++ b/frontend/src/components/DeleteConfirmationDialog.jsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import {useState} from 'react';
 import PropTypes from 'prop-types';
 import {
     Dialog,
@@ -6,8 +6,7 @@ import {
     DialogContent,
     DialogContentText,
     DialogTitle,
-    Button,
-    IconButton
+    Button
   } from '@mui/material';
 import { Delete as DeleteIcon } from '@mui/icons-material'
 

--- a/frontend/src/components/DeleteConfirmationDialog.jsx
+++ b/frontend/src/components/DeleteConfirmationDialog.jsx
@@ -1,0 +1,60 @@
+import React, {useState} from 'react';
+import PropTypes from 'prop-types';
+import {
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    Button,
+    IconButton
+  } from '@mui/material';
+import { Delete as DeleteIcon } from '@mui/icons-material'
+
+const DeleteConfirmationDialog = ({ onConfirm }) => {
+    const [open, setOpen] = useState(false);
+  
+    const handleOpen = () => setOpen(true);
+    const handleClose = () => setOpen(false);
+    const handleConfirm = () => {
+      handleClose();
+      onConfirm();
+    };
+  
+    return (
+      <>
+        <Button
+          variant="outlined"
+          color="error"
+          startIcon={<DeleteIcon />}
+          onClick={handleOpen}
+        >
+          Eliminar
+        </Button>
+  
+        <Dialog
+          open={open}
+          onClose={handleClose}
+        >
+          <DialogTitle>¿Estás seguro de que quieres eliminar este ítem?</DialogTitle>
+          <DialogContent>
+            <DialogContentText>
+              Esta acción no se puede deshacer. El objeto se eliminará permanentemente.
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={handleClose} variant="outlined">Cancelar</Button>
+            <Button onClick={handleConfirm} color="error" variant="contained">
+              Sí, eliminar
+            </Button>
+          </DialogActions>
+        </Dialog>
+      </>
+    );
+  };
+  
+  DeleteConfirmationDialog.propTypes = {
+    onConfirm: PropTypes.func.isRequired,
+  };
+  
+  export default DeleteConfirmationDialog;

--- a/frontend/src/components/EditConfirmationDialog.jsx
+++ b/frontend/src/components/EditConfirmationDialog.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+
+const EditConfirmationDialog = ({ onConfirm }) => {
+  const [open, setOpen] = useState(false);
+
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+  const handleConfirm = () => {
+    handleClose();
+    onConfirm();
+  };
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        startIcon={<EditIcon />}
+        onClick={handleOpen}
+      >
+        Editar
+      </Button>
+
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>¿Deseas editar este ítem?</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Serás redirigido al formulario de edición. Asegúrate de tener todos los datos actualizados.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose} variant="outlined">Cancelar</Button>
+          <Button onClick={handleConfirm} variant="contained" color="primary">
+            Sí, editar
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+};
+
+EditConfirmationDialog.propTypes = {
+  onConfirm: PropTypes.func.isRequired,
+};
+
+export default EditConfirmationDialog;

--- a/frontend/src/components/EditConfirmationDialog.jsx
+++ b/frontend/src/components/EditConfirmationDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Dialog,

--- a/frontend/src/components/PublishConfirmationDialog.jsx
+++ b/frontend/src/components/PublishConfirmationDialog.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Dialog,
@@ -8,7 +7,6 @@ import {
   DialogTitle,
   Button
 } from '@mui/material';
-import CheckCircleIcon from '@mui/icons-material/CheckCircle';
 
 const PublishConfirmationDialog = ({ open, onClose }) => {
   return (

--- a/frontend/src/components/PublishConfirmationDialog.jsx
+++ b/frontend/src/components/PublishConfirmationDialog.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button
+} from '@mui/material';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+
+const PublishConfirmationDialog = ({ open, onClose }) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>¡Publicación exitosa!</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          La publicación se ha llevado correctamente. ¡Ya está disponible!
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="outlined">
+          Cerrar
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+PublishConfirmationDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default PublishConfirmationDialog;

--- a/frontend/src/components/SaveConfirmationDialog.jsx
+++ b/frontend/src/components/SaveConfirmationDialog.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  Button
+} from '@mui/material';
+
+const SaveConfirmationDialog = ({ open, onClose }) => {
+  return (
+    <Dialog open={open} onClose={onClose}>
+      <DialogTitle>¡Cambios guardados!</DialogTitle>
+      <DialogContent>
+        <DialogContentText>
+          Los cambios en el objeto se han guardado correctamente. ¡Todo listo!
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} variant="outlined">Cerrar</Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+SaveConfirmationDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default SaveConfirmationDialog;

--- a/frontend/src/components/SaveConfirmationDialog.jsx
+++ b/frontend/src/components/SaveConfirmationDialog.jsx
@@ -1,4 +1,3 @@
-import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Dialog,


### PR DESCRIPTION
Descripción de la tarea
Mejorar ventanas de confirmación al editar/publicar/eliminar

Se ha añadido ventanas de confirmación al crear un ítem (publicarlo), al publicar un borrador, al eliminar un ítem, al editar su información, al crear  un nuevo anuncio